### PR TITLE
bz824858-pam-pwhistory-enforces-root-to-password-change

### DIFF
--- a/multihost_test/bz_automation/test_new_repo/conftest.py
+++ b/multihost_test/bz_automation/test_new_repo/conftest.py
@@ -1,0 +1,68 @@
+# Configuration file for multihost tests.
+
+# Load additional plugins
+from __future__ import annotations
+import pytest
+from lib.multihost import KnownTopology
+from lib.multihost import Multihost, Topology, TopologyDomain
+from lib.multihost.roles import Client
+
+
+def execute_cmd(client: Client, command):
+    """ Execute command on client """
+    cmd = client.host.exec(command)
+    return cmd
+
+
+pytest_plugins = (
+    'lib.multihost.plugin',
+)
+
+
+@pytest.fixture(scope='function')
+def bkp_pam_config(mh: Multihost, request):
+    """ create users for test """
+    client: Client = mh.sssd.client[0]
+    for bkp in ['/etc/pam.d/system-auth',
+                '/etc/security/opasswd',
+                '/etc/bashrc',
+                '/etc/pam.d/su',
+                '/etc/pam.d/su-l',
+                '/etc/security/access.conf',
+                '/etc/pam.d/sshd',
+                '/etc/pam.d/password-auth',
+                '/etc/security/limits.conf']:
+        execute_cmd(client, f"cp -vf {bkp} {bkp}_anuj")
+
+    def restoresssdconf():
+        """ Restore """
+        for bkp in ['/etc/pam.d/system-auth',
+                    '/etc/security/opasswd',
+                    '/etc/bashrc',
+                    '/etc/pam.d/su',
+                    '/etc/pam.d/su-l',
+                    '/etc/security/access.conf',
+                    '/etc/pam.d/sshd',
+                    '/etc/pam.d/password-auth',
+                    '/etc/security/limits.conf']:
+            execute_cmd(client, f"mv -vf {bkp}_anuj {bkp}")
+
+    request.addfinalizer(restoresssdconf)
+
+
+@pytest.fixture(scope='function')
+def create_localusers(mh: Multihost, request):
+    """ create users for test """
+    client: Client = mh.sssd.client[0]
+    execute_cmd(client, "useradd local_anuj")
+    execute_cmd(client, f"echo password123 | passwd --stdin local_anuj")
+    execute_cmd(client, "useradd pamtest1")
+    execute_cmd(client, "groupadd testgroup")
+
+    def restoresssdconf():
+        """ Restore """
+        execute_cmd(client, "userdel -rf local_anuj")
+        execute_cmd(client, "userdel -rf pamtest1")
+        execute_cmd(client, "groupdel testgroup")
+
+    request.addfinalizer(restoresssdconf)

--- a/multihost_test/bz_automation/test_new_repo/script/bz824858.sh
+++ b/multihost_test/bz_automation/test_new_repo/script/bz824858.sh
@@ -1,0 +1,26 @@
+# $1 - user
+# $2 - passwd
+function do_passwd {
+expect <<EOF
+set timeout 5
+spawn -noecho passwd $1
+expect_after {
+    timeout {exit 2}
+    eof {exit 1}
+}
+expect {
+    -nocase "new*" { puts "$2"; send -- "$2\r"}
+}
+expect {
+    -nocase "retype*" { puts "$2"; send -- "$2\r"}
+}
+expect {
+    -nocase "passwd: all authentication tokens updated successfully." { exit 0}
+    -nocase "passwd: Have exhausted maximum number of retries for service" { exit 3}
+}
+expect eof
+exit 2
+EOF
+}
+
+do_passwd $1 $2

--- a/multihost_test/bz_automation/test_new_repo/test_bz_automation.py
+++ b/multihost_test/bz_automation/test_new_repo/test_bz_automation.py
@@ -1,0 +1,50 @@
+import pytest
+import os
+import subprocess
+from lib.multihost import KnownTopology
+from lib.multihost.roles import Client
+
+
+def execute_cmd(client: Client, command):
+    """ Execute command on client """
+    cmd = client.host.exec(command)
+    return cmd
+
+
+@pytest.mark.topology(KnownTopology.Client)
+def test_pwhistory_enforces_root(client: Client, bkp_pam_config, create_localusers):
+    """
+    :title: bz824858-pam-pwhistory-enforces-root-to-password-change
+    :id: a87eb61c-334d-11ed-a639-845cf3eff344
+    """
+    _PASSWORD = "01_pass_change_01"
+    _PASSWORD2 = "02_change_pass_02"
+    _PASSWORD3 = "03_aother_pass_03"
+    _PASSWORD4 = "04_yet_new_pass_04"
+    execute_cmd(client, "cat /etc/pam.d/system-auth > /tmp/system-auth")
+    execute_cmd(client, "rm -f /etc/security/opasswd")
+    execute_cmd(client, "touch /etc/security/opasswd")
+    execute_cmd(client, "chown root:root /etc/security/opasswd")
+    execute_cmd(client, "chmod 600 /etc/security/opasswd")
+    execute_cmd(client, "echo R3dh4T1nC | passwd --stdin pamtest1")
+    execute_cmd(client, "> /etc/security/opasswd")
+    execute_cmd(client, "sed -i -e "
+                        "'s/^password\s\+sufficient\s\+pam_unix.so/password    "
+                        "requisite     pam_pwhistory.so remember=3 use_authtok "
+                        "enforce_for_root\\n\\0/'  /etc/pam.d/system-auth")
+    file_localtion  = "/multihost_test/bz_automation/test_new_repo/script/bz824858.sh"
+    client.host.host.transport.put_file(os.getcwd() +
+                                        file_localtion,
+                                        '/tmp/bz824858.sh')
+    for i in [_PASSWORD, _PASSWORD2, _PASSWORD3]:
+        execute_cmd(client, f"sh /tmp/bz824858.sh pamtest1 {i}")
+    with pytest.raises(subprocess.CalledProcessError):
+        execute_cmd(client, f"sh /tmp/bz824858.sh pamtest1 {_PASSWORD}")
+    execute_cmd(client, "echo R3dh4T1nC | passwd --stdin pamtest1")
+    execute_cmd(client, "> /etc/security/opasswd")
+    execute_cmd(client, "cat /tmp/system-auth > /etc/pam.d/system-auth")
+    execute_cmd(client, "sed -i -e 's/^password\s\+sufficient\s\+pam_unix.so/password    "
+                        "requisite     pam_pwhistory.so remember=3 use_authtok\\n\\0/'  "
+                        "/etc/pam.d/system-auth")
+    for i in [_PASSWORD, _PASSWORD2, _PASSWORD3, _PASSWORD4, _PASSWORD]:
+        execute_cmd(client, f"sh /tmp/bz824858.sh pamtest1 {i}")


### PR DESCRIPTION
https://pkgs.devel.redhat.com/cgit/tests/pam/tree/Regression/bz824858-pam-pwhistory-enforces-root-to-password-change