### PR TITLE
Tests: pam_pwhistory enforces root to password change history when re…

### DIFF
--- a/multihost_test/bz_automation/script/bz824858.sh
+++ b/multihost_test/bz_automation/script/bz824858.sh
@@ -1,0 +1,26 @@
+# $1 - user
+# $2 - passwd
+function do_passwd {
+expect <<EOF
+set timeout 5
+spawn -noecho passwd $1
+expect_after {
+    timeout {exit 2}
+    eof {exit 1}
+}
+expect {
+    -nocase "new*" { puts "$2"; send -- "$2\r"}
+}
+expect {
+    -nocase "retype*" { puts "$2"; send -- "$2\r"}
+}
+expect {
+    -nocase "passwd: all authentication tokens updated successfully." { exit 0}
+    -nocase "passwd: Have exhausted maximum number of retries for service" { exit 3}
+}
+expect eof
+exit 2
+EOF
+}
+
+do_passwd $1 $2

--- a/multihost_test/bz_automation/test_pam_pwhistory.py
+++ b/multihost_test/bz_automation/test_pam_pwhistory.py
@@ -1,6 +1,7 @@
 
 import pytest
 import subprocess
+import os
 
 
 def execute_cmd(multihost, command):
@@ -46,3 +47,41 @@ class TestPamBz(object):
                        'x86_64_baseos_rpms',
                        'ANUJ_AM_I_HI']:
             execute_cmd(multihost, f"echo {passwd} | passwd --stdin local_anuj")
+
+    def test_pwhistory_enforces_root(self, multihost, bkp_pam_config, create_localusers):
+        """
+        :title: bz824858-pam-pwhistory-enforces-root-to-password-change
+        :id: e7c4db96-eaf9-11eb-8fbb-845cf3eff344
+        :bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=824858
+        """
+        _PASSWORD = "01_pass_change_01"
+        _PASSWORD2 = "02_change_pass_02"
+        _PASSWORD3 = "03_aother_pass_03"
+        _PASSWORD4 = "04_yet_new_pass_04"
+        execute_cmd(multihost, "cat /etc/pam.d/system-auth > /tmp/system-auth")
+        execute_cmd(multihost, "rm -f /etc/security/opasswd")
+        execute_cmd(multihost, "touch /etc/security/opasswd")
+        execute_cmd(multihost, "chown root:root /etc/security/opasswd")
+        execute_cmd(multihost, "chmod 600 /etc/security/opasswd")
+        execute_cmd(multihost, "echo R3dh4T1nC | passwd --stdin pamtest1")
+        execute_cmd(multihost, "> /etc/security/opasswd")
+        execute_cmd(multihost, "sed -i -e 's/^password\s\+sufficient\s\+pam_unix.so/password"
+                               "    requisite     pam_pwhistory.so remember=3 "
+                               "use_authtok enforce_for_root\\n\\0/'  "
+                               "/etc/pam.d/system-auth")
+        file_location = "/multihost_test/bz_automation/script/bz824858.sh"
+        multihost.client[0].transport.put_file(os.getcwd() +
+                                               file_location,
+                                               '/tmp/bz824858.sh')
+        for i in [_PASSWORD, _PASSWORD2, _PASSWORD3]:
+            execute_cmd(multihost, f"sh /tmp/bz824858.sh pamtest1 {i}")
+        with pytest.raises(subprocess.CalledProcessError):
+            execute_cmd(multihost, f"sh /tmp/bz824858.sh pamtest1 {_PASSWORD}")
+        execute_cmd(multihost, "echo R3dh4T1nC | passwd --stdin pamtest1")
+        execute_cmd(multihost, "> /etc/security/opasswd")
+        execute_cmd(multihost, "cat /tmp/system-auth > /etc/pam.d/system-auth")
+        execute_cmd(multihost, "sed -i -e 's/^password\s\+sufficient\s\+pam_unix.so/password"
+                               "    requisite     pam_pwhistory.so remember=3 use_authtok\\n\\0/'  "
+                               "/etc/pam.d/system-auth")
+        for i in [_PASSWORD, _PASSWORD2, _PASSWORD3, _PASSWORD4, _PASSWORD]:
+            execute_cmd(multihost, f"sh /tmp/bz824858.sh pamtest1 {i}")


### PR DESCRIPTION
…setting non-root user's password

https://bugzilla.redhat.com/show_bug.cgi?id=824858