### PR TITLE
Tests: PAM can't identify the user when running from external host

### DIFF
--- a/multihost_test/bz_automation/conftest.py
+++ b/multihost_test/bz_automation/conftest.py
@@ -71,7 +71,10 @@ def bkp_pam_config(session_multihost, request):
                 '/etc/pam.d/password-auth',
                 '/etc/security/limits.conf',
                 '/etc/security/namespace.conf',
-                '/etc/security/faillock.conf']:
+                '/etc/login.defs',
+                '/etc/security/faillock.conf',
+                '/etc/sudoers',
+                '/etc/pam.d/sudo']:
         execute_cmd(session_multihost, f"cp -vf {bkp} {bkp}_anuj")
 
     def restoresssdconf():
@@ -87,7 +90,10 @@ def bkp_pam_config(session_multihost, request):
                     '/etc/pam.d/password-auth',
                     '/etc/security/limits.conf',
                     '/etc/security/namespace.conf',
-                    '/etc/security/faillock.conf']:
+                    '/etc/login.defs',
+                    '/etc/security/faillock.conf',
+                    '/etc/sudoers',
+                    '/etc/pam.d/sudo']:
             execute_cmd(session_multihost, f"mv -vf {bkp}_anuj {bkp}")
 
     request.addfinalizer(restoresssdconf)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHEL-16727