### PR TITLE
Tests: Fix CVE-2026-54411 test failures and Python 3.13 SyntaxWarnings

### DIFF
--- a/multihost_test/bz_automation/conftest.py
+++ b/multihost_test/bz_automation/conftest.py
@@ -169,3 +169,5 @@ def setup_session(session_multihost, request):
     execute_cmd(session_multihost, "yum update -y shadow-utils")
     execute_cmd(session_multihost, "yum install -y gcc pam-devel")
     execute_cmd(session_multihost, "yum install -y expect")
+    session_multihost.client[0].run_command(
+        "yum install -y libdb-utils", raiseonerr=False)

--- a/multihost_test/bz_automation/test_automation.py
+++ b/multihost_test/bz_automation/test_automation.py
@@ -100,8 +100,8 @@ class TestPamBz(object):
         execute_cmd(multihost, '> /tmp/xauthlog')
         execute_cmd(multihost, f"useradd {TUSER}")
         execute_cmd(multihost, "cp -f myxauth /myxauth")
-        execute_cmd(multihost, 'sed -i "s/pam_xauth\.so/pam_xauth\.so '
-                               'debug xauthpath=\/myxauth/g" /etc/pam.d/su')
+        execute_cmd(multihost, 'sed -i "s/pam_xauth\\.so/pam_xauth\\.so '
+                               'debug xauthpath=\\/myxauth/g" /etc/pam.d/su')
         execute_cmd(multihost, 'echo "pam-xauth-tester    hard    nproc   '
                                '0" >> /etc/security/limits.conf')
         execute_cmd(multihost, 'mkdir -p /root/.xauth')

--- a/multihost_test/bz_automation/test_cve_2026_54411.py
+++ b/multihost_test/bz_automation/test_cve_2026_54411.py
@@ -94,8 +94,13 @@ class TestCVE202654411(object):
         """
         client = multihost.client[0]
         use_gdbm = is_gdbm(multihost)
-        db_ext = ".gdbm" if use_gdbm else ".db"
-        db_path = f"/etc/security/cve_test_users{db_ext}"
+        base_path = "/etc/security/cve_test_users"
+        if use_gdbm:
+            db_file = f"{base_path}.gdbm"
+            pam_db_path = db_file
+        else:
+            db_file = f"{base_path}.db"
+            pam_db_path = base_path
         pam_service = "/etc/pam.d/test_pam_userdb_cve"
         helper_script = "/tmp/pam_userdb_timing.py"
         file_location = "/multihost_test/bz_automation/script/pam_userdb_timing.py"
@@ -107,8 +112,8 @@ class TestCVE202654411(object):
             entries = [("user1", "password1"),
                        ("user2", "password2"),
                        ("user3", "longpassword123")]
-            create_db(client, db_path, entries, use_gdbm)
-            setup_pam_service(client, pam_service, db_path)
+            create_db(client, db_file, entries, use_gdbm)
+            setup_pam_service(client, pam_service, pam_db_path)
 
             output = client.run_command(
                 f"python3 {helper_script}").stdout_text
@@ -121,7 +126,7 @@ class TestCVE202654411(object):
             assert results["functional"]["wrong_user"], \
                 "Unknown user should be rejected"
         finally:
-            client.run_command(f"rm -f {db_path}", raiseonerr=False)
+            client.run_command(f"rm -f {db_file}", raiseonerr=False)
             client.run_command(f"rm -f {pam_service}", raiseonerr=False)
             client.run_command(f"rm -f {helper_script}", raiseonerr=False)
 
@@ -154,8 +159,13 @@ class TestCVE202654411(object):
         """
         client = multihost.client[0]
         use_gdbm = is_gdbm(multihost)
-        db_ext = ".gdbm" if use_gdbm else ".db"
-        db_path = f"/etc/security/cve_icase{db_ext}"
+        base_path = "/etc/security/cve_icase"
+        if use_gdbm:
+            db_file = f"{base_path}.gdbm"
+            pam_db_path = db_file
+        else:
+            db_file = f"{base_path}.db"
+            pam_db_path = base_path
         pam_service = "/etc/pam.d/test_pam_userdb_icase"
 
         helper_script = "/tmp/pam_userdb_icase.py"
@@ -163,8 +173,8 @@ class TestCVE202654411(object):
 
         try:
             entries = [("user1", "Password1")]
-            create_db(client, db_path, entries, use_gdbm)
-            setup_pam_service(client, pam_service, db_path, "icase")
+            create_db(client, db_file, entries, use_gdbm)
+            setup_pam_service(client, pam_service, pam_db_path, "icase")
 
             client.transport.put_file(
                 os.getcwd() + file_location, helper_script)
@@ -179,6 +189,6 @@ class TestCVE202654411(object):
                 "Case-insensitive match (uppercase) should succeed"
             assert not results["wrong"], "Wrong password should fail"
         finally:
-            client.run_command(f"rm -f {db_path}", raiseonerr=False)
+            client.run_command(f"rm -f {db_file}", raiseonerr=False)
             client.run_command(f"rm -f {pam_service}", raiseonerr=False)
             client.run_command(f"rm -f {helper_script}", raiseonerr=False)

--- a/multihost_test/bz_automation/test_pam_pwhistory.py
+++ b/multihost_test/bz_automation/test_pam_pwhistory.py
@@ -79,7 +79,7 @@ class TestPamBz(object):
         execute_cmd(multihost, "chmod 600 /etc/security/opasswd")
         execute_cmd(multihost, "echo R3dh4T1nC | passwd --stdin pamtest1")
         execute_cmd(multihost, "> /etc/security/opasswd")
-        execute_cmd(multihost, "sed -i -e 's/^password\s\+sufficient\s\+pam_unix.so/password"
+        execute_cmd(multihost, "sed -i -e 's/^password\\s\\+sufficient\\s\\+pam_unix.so/password"
                                "    requisite     pam_pwhistory.so remember=3 "
                                "use_authtok enforce_for_root\\n\\0/'  "
                                "/etc/pam.d/system-auth")
@@ -96,7 +96,7 @@ class TestPamBz(object):
         execute_cmd(multihost, "echo R3dh4T1nC | passwd --stdin pamtest1")
         execute_cmd(multihost, "> /etc/security/opasswd")
         execute_cmd(multihost, "cat /tmp/system-auth > /etc/pam.d/system-auth")
-        execute_cmd(multihost, "sed -i -e 's/^password\s\+sufficient\s\+pam_unix.so/password"
+        execute_cmd(multihost, "sed -i -e 's/^password\\s\\+sufficient\\s\\+pam_unix.so/password"
                                "    requisite     pam_pwhistory.so remember=3 use_authtok\\n\\0/'  "
                                "/etc/pam.d/system-auth")
         for i in [_PASSWORD, _PASSWORD2, _PASSWORD3, _PASSWORD4, _PASSWORD]:


### PR DESCRIPTION
Install libdb-utils in session setup so db_load is available on RHEL 9 for pam_userdb CVE tests. Fix invalid escape sequences (\., \/, \s) in test_automation.py and test_pam_pwhistory.py that produce SyntaxWarnings on Python 3.13.